### PR TITLE
fix: prevent explicit-function-return-type warnings for jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Add `extends: '@flowscripter/eslint-config'` to your `.eslintrc.js` file.
 
 ## Build
 
+Firstly: 
+
+```
+npm install
+```
+
+then:
+
 Test: `npm test`
 
 Dogfooding: `npm run lint`

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,8 @@ module.exports = {
                 'jest/no-focused-tests': 'error',
                 'jest/no-identical-title': 'error',
                 'jest/prefer-to-have-length': 'warn',
-                'jest/valid-expect': 'error'
+                'jest/valid-expect': 'error',
+                '@typescript-eslint/explicit-function-return-type': 'off'
             }
         }
     ]


### PR DESCRIPTION
docs: mention install